### PR TITLE
Specify hostname 0.0.0.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,4 +81,4 @@ def settings():
 
 # ======== Main ============================================================== #
 if __name__ == "__main__":
-    app.run(debug=True, use_reloader=True)
+    app.run(debug=True, use_reloader=True, host="0.0.0.0")


### PR DESCRIPTION
Use 0.0.0.0 as the host (which is like localhost but listen on all IPs) so it can run on remote servers like on Repl.it.

I saw that a repl.it badge was added (super cool!) #30 but it wasn't working when I tried it. This will fix it, and it runs nicely.
<img width="1920" alt="Screen Shot 2019-12-10 at 2 53 05 PM" src="https://user-images.githubusercontent.com/587518/70576353-8e357d00-1b5d-11ea-8bfd-cbae08cc3d50.png">
