### PR TITLE
Update helpers.py

### DIFF
--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -46,7 +46,7 @@ def change_user(**kwargs):
         user = s.query(tabledef.User).filter(tabledef.User.username.in_([username])).first()
         for arg, val in kwargs.items():
             if val != "":
-                setattr(user, arg, val)
+                setattr(user, arg, val.decode('utf8'))
         s.commit()
 
 


### PR DESCRIPTION
add utf8 decode to user-update setattr function, to match behavior for password storing on new-user create. 

Current behavior:
utf8 decode is called on new-user-create password but not user-update password. 
cannot log in again after updating password

behavior with fix:
user can update password and log in again